### PR TITLE
Update FileChooser.java

### DIFF
--- a/src/org/pyload/android/client/module/FileChooser.java
+++ b/src/org/pyload/android/client/module/FileChooser.java
@@ -67,8 +67,8 @@ public class FileChooser extends ListActivity {
 		// TODO Auto-generated method stub
 		super.onListItemClick(l, v, position, id);
 		Option o = adapter.getItem(position);
-		if (o.getData().equalsIgnoreCase("folder")
-				|| o.getData().equalsIgnoreCase("parent directory")) {
+		if (o.getData().equalsIgnoreCase(R.string.folder)
+				|| o.getData().equalsIgnoreCase(R.string.parent_dir)) {
 			currentDir = new File(o.getPath());
 			fill(currentDir);
 		} else {


### PR DESCRIPTION
Replace hardcoded "folder" and "parent directory" with "R.string.folder" and "R.string.parent_dir" in function "onListItemClick".

That should fix the bug reported by Gronkdalonka (Unable to open Subfolders).
